### PR TITLE
Add documentation for endpoints and schema doc

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1,0 +1,65 @@
+#### Exhibits: ####
+- GET {omeka-root}/api/neatline_exhibits
+
+  Returns an array of JSON representations for all exhibits where `o:public` equals true
+
+  Optional param `jwt`: authenticates a user, including all private exhibits they have permission to view in the returned array
+
+- GET {omeka-root}/api/neatline_exhibits/{exhibit-id}
+
+  Returns the exhibit’s JSON representation
+
+  Required param `jwt`: authenticates a user, returning the exhibit if they have permission to view it
+
+- POST {omeka-root}/api/neatline_exhibits
+
+  Creates an exhibit from a JSON payload in the request body
+
+  Required header `Content-Type`: `application/json`
+
+  Required param `jwt`: authenticates the user who will own the created exhibit
+
+- PATCH {omeka-root}/api/neatline_exhibits/{exhibit-id}
+
+  Updates an existing exhibit with the JSON payload in the request body
+
+  Required header `Content-Type`: `application/json`
+
+  Required param `jwt`: authenticates a user with permission to edit the exhibit
+
+- DELETE {omeka-root}/api/neatline_exhibits/{exhibit-id}
+
+  Destroys an existing exhibit
+
+  Required param `jwt`: authenticates a user with permission to destroy the exhibit
+
+#### Records: ####
+- GET {omeka-root}/api/neatline_records
+
+  Returns an array of JSON representations for all records
+
+  Optional param `jwt`: authenticates a user, including records from private exhibits they have permission to view in the returned array
+
+  Optional param `exhibit_id`: filters the returned record representations to only include those that belong to the specified exhibit
+
+- POST {omeka-root}/api/neatline_records
+
+  Creates an exhibit from a JSON payload in the request body
+
+  Required header `Content-Type`: `application/json`
+
+  Required param `jwt`: authenticates a user with permission to create a record
+
+- PATCH {omeka-root}/api/neatline_records/{record-id}
+
+  Updates an existing record with the JSON payload in the request body
+
+  Required header `Content-Type`: `application/json`
+
+  Required param `jwt`: authenticates a user with permission to edit the record
+
+- DELETE {omeka-root}/api/neatline_records/{record-id}
+
+  Destroys an existing record
+
+  Required param `jwt`: authenticates a user with permission to destroy the record

--- a/docs/exhibit-schema.md
+++ b/docs/exhibit-schema.md
@@ -1,0 +1,37 @@
+#### API schema for Neatline exhibits ####
+The following fields must be supported by the back-end adapter for *exhibit* objects. Fields that are new as of 3.0 are indicated in **bold**.
+
+API property             | SQL column type
+---                      | ---
+o:id                     | INT(10) UNSIGNED NOT NULL AUTO_INCREMENT
+o:owner_id               | INT(10) UNSIGNED NOT NULL
+o:added                  | TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+o:modified               | TIMESTAMP NULL
+o:published              | TIMESTAMP NULL
+o:item_query             | TEXT NULL
+o:spatial_layers         | TEXT NULL
+o:spatial_layer          | TEXT NULL
+o:image_layer            | TEXT NULL
+o:image_height           | SMALLINT UNSIGNED NULL
+o:image_width            | SMALLINT UNSIGNED NULL
+o:zoom_levels            | SMALLINT UNSIGNED NULL
+o:wms_address            | TEXT NULL
+o:wms_layers             | TEXT NULL
+o:widgets                | TEXT NULL
+o:title                  | TEXT NULL
+o:slug                   | VARCHAR(100) NOT NULL
+o:narrative              | LONGTEXT NULL
+o:spatial_querying       | TINYINT(1) NOT NULL
+o:public                 | TINYINT(1) NOT NULL
+o:styles                 | TEXT NULL
+o:map_focus              | VARCHAR(100) NULL
+o:map_zoom               | INT(10) UNSIGNED NULL
+o:accessible_url         | TEXT NULL
+o:map_restricted_extent  | TEXT NULL
+o:map_min_zoom           | SMALLINT UNSIGNED NULL
+o:map_max_zoom           | SMALLINT UNSIGNED NULL
+**o:tile_address**       | TEXT NULL
+**o:image_attribution**  | TEXT NULL
+**o:wms_attribution**    | TEXT NULL
+**o:tile_attribution**   | TEXT NULL
+**o:exhibit_type**       | INT(10) UNSIGNED NOT NULL DEFAULT 0

--- a/docs/migration-from-2-6-1.md
+++ b/docs/migration-from-2-6-1.md
@@ -1,0 +1,8 @@
+#### Notes on migrating exhibits from Neatline 2.6.1 instances ###
+
+- The `exhibit_type` property has been added to exhibits in 3.0 and should be determined as follows:
+    - If the exhibit's `spatial_layer` value is not null, `exhibit_type` should be set to 0 (the value corresponding to 'MAP')
+    - If `spatial_layer` is null and `image_layer` has a value other than null or an empty string, `exhibit_type` should be set to 1 (the value corresponding to 'IMAGE')
+    - If `spatial_layer` is null and `image_layer` is null or empty but `wms_address` and/or `spatial_layers` has a value other than null or an empty string, `exhibit_type` should be set to 0
+    - If `spatial_layer`, `image_layer`, `wms_address`, and `spatial_layers` are all null or empty, `exhibit_type` should be set to -1 (the value corresponding to 'UNDEFINED')
+- The `spatial_layer` exhibit property has been updated to use keys from an enumerated set of types, and certain layer types may be deprecated for general-purpose use due to changes in their APIs. As this implementation is still in progress, decisions about how specifically to process this property should be made later on.

--- a/docs/record-schema.md
+++ b/docs/record-schema.md
@@ -1,0 +1,44 @@
+#### API schema for Neatline records ####
+The following fields must be supported by the back-end adapter for *record* objects. Fields that are new as of 3.0 are indicated in **bold**.
+
+API property             | SQL column type
+---                      | ---
+o:id                     | INT(10) UNSIGNED NOT NULL AUTO_INCREMENT
+o:owner_id               | INT(10) UNSIGNED NOT NULL
+o:item_id                | INT(10) UNSIGNED NULL
+o:exhibit_id             | INT(10) UNSIGNED NULL
+o:added                  | TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+o:modified               | TIMESTAMP NULL
+o:is_coverage            | TINYINT(1) NOT NULL
+o:is_wms                 | TINYINT(1) NOT NULL
+o:slug                   | VARCHAR(100) NULL
+o:title                  | MEDIUMTEXT NULL
+o:item_title             | MEDIUMTEXT NULL
+o:body                   | MEDIUMTEXT NULL
+o:coverage               | GEOMETRY NOT NULL
+o:tags                   | TEXT NULL
+o:widgets                | TEXT NULL
+o:presenter              | VARCHAR(100) NULL
+o:fill_color             | VARCHAR(100) NULL
+o:fill_color_select      | VARCHAR(100) NULL
+o:stroke_color           | VARCHAR(100) NULL
+o:stroke_color_select    | VARCHAR(100) NULL
+o:fill_opacity           | DECIMAL(3,2) NULL
+o:fill_opacity_select    | DECIMAL(3,2) NULL
+o:stroke_opacity         | DECIMAL(3,2) NULL
+o:stroke_opacity_select  | DECIMAL(3,2) NULL
+o:stroke_width           | INT(10) UNSIGNED NULL
+o:point_radius           | INT(10) UNSIGNED NULL
+o:zindex                 | INT(10) UNSIGNED NULL
+o:weight                 | INT(10) UNSIGNED NULL
+o:start_date             | VARCHAR(100) NULL
+o:end_date               | VARCHAR(100) NULL
+o:after_date             | VARCHAR(100) NULL
+o:before_date            | VARCHAR(100) NULL
+o:point_image            | VARCHAR(100) NULL
+o:wms_address            | TEXT NULL
+o:wms_layers             | TEXT NULL
+o:min_zoom               | INT(10) UNSIGNED NULL
+o:max_zoom               | INT(10) UNSIGNED NULL
+o:map_zoom               | INT(10) UNSIGNED NULL
+o:map_focus              | VARCHAR(100) NULL


### PR DESCRIPTION
### What does this PR do?
Adds a 'docs' folder with markdown files containing notes relevant to the implementation of back-end adapters and migration scripts for Neatline 3, including:
- The current full set of REST API endpoints the adapter must provide
- The schema for exhibit and record objects, with additions since 2.6.1 indicated in bold
- Notes toward the eventual migration project of 2.6.1 exhibits into 3.0

### What issues does it address?
- Closes #31, closes #32, closes #33 

### How to test
- Click each of the files listed in https://github.com/performant-software/neatline-3/tree/aks/documentation/docs to confirm they appear correctly when viewed in this GitHub repository.