### PR TITLE
Fix URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Neatline Single Page Application (Neatline SPA)
 
-This repository contains the front end components of Neatline, a suite of tools for scholars, students, and curators to tell stories with maps and timelines. Neatline SPA is in active development. This application relies on a separate back end adapter, called [Neatline Omeka S](https://github.com/performant-software/neatline-omeka-s) to provide API endpoints for its data storage and retrieval. That adapter can also include a bundled build of this SPA, to make it easy to install Neatline for Omeka S in one step.
+This repository contains the front end components of Neatline, a suite of tools for scholars, students, and curators to tell stories with maps and timelines. Neatline SPA is in active development. This application relies on a separate back end adapter, called [Neatline Omeka S](https://github.com/scholarslab/neatline-omeka-s) to provide API endpoints for its data storage and retrieval. That adapter can also include a bundled build of this SPA, to make it easy to install Neatline for Omeka S in one step.
 
 ### Development Setup
-For development purposes, this repository is included as a git submodule in the Neatline adapter for Omeka S. To use an Omeka S instance as the environment for Neatline SPA installation and/or development, please see the instructions at https://github.com/performant-software/neatline-omeka-s.
+For development purposes, this repository is included as a git submodule in the Neatline adapter for Omeka S. To use an Omeka S instance as the environment for Neatline SPA installation and/or development, please see the instructions at https://github.com/scholarslab/neatline-omeka-s.


### PR DESCRIPTION
Should now be pointing to Scholars' Lab's repos in all cases.