### PR TITLE
Fix spatial_layers update

### DIFF
--- a/src/components/ExhibitForm/index.js
+++ b/src/components/ExhibitForm/index.js
@@ -160,11 +160,19 @@ class ExhibitForm extends Component {
 	markUnsaved = (event) => {
 		// Update the cache
 		if(typeof event !== 'undefined'){
-			this.props.dispatch(updateExhibitCache({
-				setValues: {
-					[event.target.name]: event.target.value
-				}
-			}));
+			if(event.target.selectedOptions){
+				this.props.dispatch(updateExhibitCache({
+					setValues: {
+						[event.target.name]: Array.from(event.target.selectedOptions, option => option.value)
+					}
+				}));
+			}else{
+				this.props.dispatch(updateExhibitCache({
+					setValues: {
+						[event.target.name]: event.target.value
+					}
+				}));
+			}
 			// this.props.dispatch(updateExhibitCache({setValues:{[name]:value}}));
 		}else{
 			console.log("Skipping cache update");

--- a/src/components/ExhibitForm/index.js
+++ b/src/components/ExhibitForm/index.js
@@ -157,13 +157,13 @@ class ExhibitForm extends Component {
 	}
 
 	// Sets the unsaved changes flag
-	markUnsaved = (event) => {
+	markUnsaved = (event, data) => {
 		// Update the cache
 		if(typeof event !== 'undefined'){
-			if(event.target.selectedOptions){
+			if(data && data.value){
 				this.props.dispatch(updateExhibitCache({
 					setValues: {
-						[event.target.name]: Array.from(event.target.selectedOptions, option => option.value)
+						[event.target.name]: data.value
 					}
 				}));
 			}else{


### PR DESCRIPTION
The way that markUnsaved was written does not seem to accommodate react multiple select fields, leading to these fields (e.g. spatial_layers) not being correctly updated. This fixes that.